### PR TITLE
Always return null for empty strings

### DIFF
--- a/lib/helpers/converter_functions.dart
+++ b/lib/helpers/converter_functions.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 /// This attempts to intelligently cast any value to the desired type.
 T intelligentCast<T>(dynamic value) {
   // instead of empty string we want to return null
-  if (T.toString() == 'String' && value.toString().isEmpty) return null;
+  if (value.toString().isEmpty) return null;
 
   // already expected type, return it
   if (value is T) return value;


### PR DESCRIPTION
Otherwise empty values from `CardSettingsInt` would throw a FormatException:

```
E/flutter (16997): [ERROR:flutter/shell/common/shell.cc(181)] Dart Error: Unhandled exception:
E/flutter (16997): FormatException: Invalid number (at character 1)
E/flutter (16997): 
E/flutter (16997): ^
E/flutter (16997): 
E/flutter (16997): #0      int._throwFormatException (dart:core/runtime/libintegers_patch.dart:128:7)
E/flutter (16997): #1      int.parse (dart:core/runtime/libintegers_patch.dart:52:32)
E/flutter (16997): #2      intelligentCast (package:card_settings/helpers/converter_functions.dart:24:41)
E/flutter (16997): #3      new CardSettingsInt.<anonymous closure> (package:card_settings/widgets/numeric_fields/card_settings_int.dart:54:30)
E/flutter (16997): #4      FormFieldState._validate (package:flutter/src/widgets/form.dart)
```