### PR TITLE
Update card_settings_phone.dart

### DIFF
--- a/lib/widgets/text_fields/card_settings_phone.dart
+++ b/lib/widgets/text_fields/card_settings_phone.dart
@@ -131,7 +131,7 @@ class CardSettingsPhone extends StatelessWidget
       labelWidth: labelWidth,
       labelAlign: labelAlign,
       contentAlign: contentAlign,
-      initialValue: formatAsPhoneNumber(initialValue.toString()),
+      initialValue: initialValue!=null ? formatAsPhoneNumber(initialValue.toString()): "",
       contentOnNewLine: contentOnNewLine,
       maxLength: maxLength,
       hintText: hintText,


### PR DESCRIPTION
Issue #127 , talks about how you cannot leave initialText empty while using CardSettingsPhone, and it looks like something that could be easily fixed by changing a parameter while calling this class's build method. If you're accepting contributions. Here is a PR