### PR TITLE
use alwaysUse24HourFormat from MediaQuery in CupertinoDatePicker

### DIFF
--- a/lib/widgets/picker_fields/card_settings_datetime_picker.dart
+++ b/lib/widgets/picker_fields/card_settings_datetime_picker.dart
@@ -148,6 +148,7 @@ class _CardSettingsDateTimePickerState extends FormFieldState<DateTime> {
               didChange(newDateTime);
               if (widget.onChanged != null) widget.onChanged(newDateTime);
             },
+            use24hFormat: MediaQuery.of(context).alwaysUse24HourFormat,
           ),
         );
       },

--- a/lib/widgets/picker_fields/card_settings_time_picker.dart
+++ b/lib/widgets/picker_fields/card_settings_time_picker.dart
@@ -150,6 +150,7 @@ class _CardSettingsTimePickerState extends FormFieldState<TimeOfDay> {
               if (widget.onChanged != null)
                 widget.onChanged(TimeOfDay.fromDateTime(newDateTime));
             },
+            use24hFormat: MediaQuery.of(context).alwaysUse24HourFormat,
           ),
         );
       },


### PR DESCRIPTION
With this change the picker shows 24 hour format according to device settings instead of always am/pm (at least on iOS).